### PR TITLE
Overlater all håndtering av ANS1 encoding til bouncycastle

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule ".travis"]
+	path = .travis
+	url = https://github.com/digipost/digipost-open-travis-config

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,23 @@
-cache:
-  directories:
-  - $HOME/.m2/repository
-
-sudo: false
-
+dist: trusty
 language: java
 jdk:
 - oraclejdk8
+- openjdk11    # open source libraries should target Java 8, but
+- openjdk12    # it is nice to verify it also builds with later JDKs.
+
+cache:
+  directories:
+  - $HOME/.m2
 
 env:
   global:
   - secure: inKpWOw6hzOBk6nVi4mxlbe2PjKhohQXKytzMkyXIoGdNqUTZ/WK/kaaKhUnloLR4QXepIPbkRArZ1NJ+ef/Go0aW1EwV6YstlqPujdm8M6hwmwLnc3yyN9tPEG4LJ0uwaYSB0m3tLQeqJ0kU+LZaGS75Kje4kQw2bxbESTgTQKaxhv79/wllshicWCNJkTUsMrBhnv4CWkT/pKlWPwXI2AoEY9cyjxjuma3ftDEgILL5lLXtBmQIQo5nmg0JeJHijNSgNDb7lI4iB1hm4Ntrrg6A9P6S4U4nSP4qJtLmIaZAp4pgnsSeHO4uIYvVP5XEBqRVjuvRwuVoRpWTKmsUX2Y2UfHy4XsQODS+qAZaIbsNHZ44bA+p6ZxtMWoTSMlQg8EChFm0VKVcWFJF53oM+2yUvc086OYu3iOcwlmOZHiVIb0fhVU4goeR8RnAZhq8djEe2hf5zfdsb1fd9yE2NsJoOwNJgC/Zi4V2fxZ1NeTuKAIxh/117fowS8W9cvlcK/5rJAsqa6WF1g/BZge60FQ0IS9o5wNLCUCbjw+TE/SH8ud8j7bwrvZT/FK6goWj0YJcJ4SS/fsfbjesTZxNF146wgR75w4YWpNgE/TsaXiuYIWTM1/unV7FeBCVdujKYBQW+w3WuZQTUvcKRiu8wcCzqGP4s3FBTzb80hck1E=
   - secure: BEC+Q7kCQ8fafmGYuahyJ7CbYLwJ9fJKRR3PyKTNIxVt3C4PJneRFZqlKoXZs0Cca0q8I09/X6Uu5mcgnKuxRkxZWYDA9mqLUthDhu8XwVL6q5180lKwa10SKDEHyYRPU1nkSx5S1z0xfPUhmH/fnHLyZzTtOrpDi8RXvXckeedviirQoGOhOu+HIfDGetPbTKpCs6t2iyoXEAevRxfO04dn5dgnV7qXpJXcPJVsuLoGE9wYlu09Gsnjo2T76jpcMpa5/myHRVscaQfS2a7rw0lMeZhmAzn0dGB+yaUSyxSgawiijhVYAN4yneNS5LH94Tqf6/TT7PoyNl/r78JtrxIf0ekRowgJTpCjxHoYfGZurmpYI3V0gmHtT1v6waV+KopoIGDqnZ7iBFWXulfCCo4Ca9o2m7J0OG1pqeofBegOzamfWgTOpEF0bxgXjraQqTXUMCUbDSPP4wkYB1J2h5tAZZFr4ofRe5zsxs+wTlza3EKzlpoCmy21uPKVJ2P9v02bObzkWcY+6QzfeI45yakWSsrnzXzWc1dEQMFxHp+EW/P6zIM3VUr4LZjG7EtHQgxGy3AyQt11bowvakyjrxYle8QY/gmSGR+mTxAXw72AsbN0bR+EFfXg9MFpuv8wZutiQHPHiBak0ETAO3F2gCLOJuwpAXUuQsxNXRnHUdc=
 
-before_install:
-  - echo "<settings><servers><server><id>sonatype-oss-nexus-snapshots</id><username>\${env.SONATYPE_USER}</username><password>\${env.SONATYPE_PASS}</password></server></servers></settings>" > ~/.m2/deploy-settings.xml
-
 install: true
 
-script:
-- export commitMessage="$(git --no-pager log -1 HEAD --pretty=%s)"
-- echo "Commit message is '$commitMessage'"
-- export mavenBuildGoal=$(if [[ "$commitMessage" == "Release:prepare release"* ]]; then echo verify; else echo deploy; fi)
-- echo "Maven will '${mavenBuildGoal}'"
-- mvn clean ${mavenBuildGoal} --update-snapshots --settings ~/.m2/deploy-settings.xml
+before_script:
+  - cp .travis/maven.settings.xml ~/.m2/settings.xml
 
+script:
+  - mvn clean deploy --update-snapshots

--- a/pom.xml
+++ b/pom.xml
@@ -48,12 +48,12 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.61</version>
+            <version>1.64</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.61</version>
+            <version>1.64</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>certificate-validator</artifactId>
-    <version>2.1-SNAPSHOT</version>
+    <version>2.0.1</version>
     <name>Digipost Certificate Validator</name>
     <description>Library for validating certificates.</description>
 
@@ -299,7 +299,7 @@
         <connection>scm:git:git@github.com:digipost/certificate-validator.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/certificate-validator.git</developerConnection>
         <url>https://github.com/digipost/certificate-validator/</url>
-        <tag>HEAD</tag>
+        <tag>2.0.1</tag>
     </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     </parent>
 
     <artifactId>certificate-validator</artifactId>
-    <version>2.0.1</version>
+    <version>2.1-SNAPSHOT</version>
     <name>Digipost Certificate Validator</name>
     <description>Library for validating certificates.</description>
 
@@ -299,7 +299,7 @@
         <connection>scm:git:git@github.com:digipost/certificate-validator.git</connection>
         <developerConnection>scm:git:git@github.com:digipost/certificate-validator.git</developerConnection>
         <url>https://github.com/digipost/certificate-validator/</url>
-        <tag>2.0.1</tag>
+        <tag>HEAD</tag>
     </scm>
 
 </project>

--- a/src/main/java/no/digipost/security/ocsp/OcspUtils.java
+++ b/src/main/java/no/digipost/security/ocsp/OcspUtils.java
@@ -16,7 +16,14 @@
 package no.digipost.security.ocsp;
 
 import no.digipost.security.DigipostSecurity;
-import org.bouncycastle.asn1.*;
+import org.bouncycastle.asn1.ASN1Encodable;
+import org.bouncycastle.asn1.ASN1ObjectIdentifier;
+import org.bouncycastle.asn1.ASN1OctetString;
+import org.bouncycastle.asn1.ASN1Primitive;
+import org.bouncycastle.asn1.ASN1Sequence;
+import org.bouncycastle.asn1.ASN1TaggedObject;
+import org.bouncycastle.asn1.DERSequence;
+import org.bouncycastle.asn1.DLSequence;
 import org.bouncycastle.asn1.ocsp.OCSPObjectIdentifiers;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.cert.X509CertificateHolder;
@@ -57,9 +64,10 @@ public final class OcspUtils {
         try {
             ASN1OctetString base = (ASN1OctetString) ASN1Primitive.fromByteArray(authorityInfoAccessValue);
             ASN1Sequence seq = (ASN1Sequence) ASN1Primitive.fromByteArray(base.getOctets());
-            Enumeration objects = seq.getObjects();
+            @SuppressWarnings("unchecked")
+            Enumeration<ASN1Encodable> objects = seq.getObjects();
             while (objects.hasMoreElements()) {
-                ASN1Encodable elm = (ASN1Encodable) objects.nextElement();
+                ASN1Encodable elm = objects.nextElement();
                 if (elm instanceof ASN1Sequence) {
                     ASN1Encodable id = ((ASN1Sequence)elm).getObjectAt(0);
                     if (OCSPObjectIdentifiers.id_pkix_ocsp.equals(id)) {

--- a/src/main/java/no/digipost/security/ocsp/OcspUtils.java
+++ b/src/main/java/no/digipost/security/ocsp/OcspUtils.java
@@ -16,12 +16,7 @@
 package no.digipost.security.ocsp;
 
 import no.digipost.security.DigipostSecurity;
-import org.bouncycastle.asn1.ASN1Encodable;
-import org.bouncycastle.asn1.ASN1ObjectIdentifier;
-import org.bouncycastle.asn1.ASN1Primitive;
-import org.bouncycastle.asn1.DEROctetString;
-import org.bouncycastle.asn1.DERTaggedObject;
-import org.bouncycastle.asn1.DLSequence;
+import org.bouncycastle.asn1.*;
 import org.bouncycastle.asn1.ocsp.OCSPObjectIdentifiers;
 import org.bouncycastle.asn1.x509.Extension;
 import org.bouncycastle.cert.X509CertificateHolder;
@@ -47,7 +42,7 @@ public final class OcspUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(OcspUtils.class);
 
-    private static final DLSequence ASN1_OCSP_SIGNING = new DLSequence(new ASN1ObjectIdentifier("1.3.6.1.5.5.7.3.9"));
+    private static final ASN1Sequence ASN1_OCSP_SIGNING = new DERSequence(new ASN1ObjectIdentifier("1.3.6.1.5.5.7.3.9"));
 
     private static final ASN1ObjectIdentifier ASN1_EXTENDED_KEY_USAGE = new ASN1ObjectIdentifier("2.5.29.37");
 
@@ -60,16 +55,16 @@ public final class OcspUtils {
             return Optional.empty();
         }
         try {
-            DEROctetString base = (DEROctetString) ASN1Primitive.fromByteArray(authorityInfoAccessValue);
-            DLSequence seq = (DLSequence) ASN1Primitive.fromByteArray(base.getOctets());
-            Enumeration<?> objects = seq.getObjects();
+            ASN1OctetString base = (ASN1OctetString) ASN1Primitive.fromByteArray(authorityInfoAccessValue);
+            ASN1Sequence seq = (ASN1Sequence) ASN1Primitive.fromByteArray(base.getOctets());
+            Enumeration objects = seq.getObjects();
             while (objects.hasMoreElements()) {
-                Object elm = objects.nextElement();
-                if (elm instanceof DLSequence) {
-                    ASN1Encodable id = ((DLSequence)elm).getObjectAt(0);
+                ASN1Encodable elm = (ASN1Encodable) objects.nextElement();
+                if (elm instanceof ASN1Sequence) {
+                    ASN1Encodable id = ((ASN1Sequence)elm).getObjectAt(0);
                     if (OCSPObjectIdentifiers.id_pkix_ocsp.equals(id)) {
-                        DERTaggedObject dt = (DERTaggedObject)((DLSequence)elm).getObjectAt(1);
-                        DEROctetString dos =  (DEROctetString)dt.getObjectParser(dt.getTagNo(), true);
+                        ASN1TaggedObject dt = (ASN1TaggedObject)((DLSequence)elm).getObjectAt(1);
+                        ASN1OctetString dos =  (ASN1OctetString)dt.getObjectParser(dt.getTagNo(), true);
                         return Optional.of(URI.create(new String(dos.getOctets())));
                     }
                 }


### PR DESCRIPTION
Vår eksplisitte casting til DER og DL encoding feiler ved oppgradering til nyere versjon av bouncycastle. Har derfor generalisert koden vår til kun å benytte generelle ANS1-typer, da vi ikke trenger å forholde oss til encoding og kan overlate dette helt til bouncycastle.

Koden skal nå fungere med bouncycastle både < 1.63 og >= 1.63