### PR TITLE
Support custom clock

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>no.digipost</groupId>
         <artifactId>digipost-open-super-pom</artifactId>
-        <version>6</version>
+        <version>7</version>
     </parent>
 
     <artifactId>certificate-validator</artifactId>
@@ -31,7 +31,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.5.0-M1</version>
+                <version>5.8.0-M1</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -42,23 +42,23 @@
         <dependency>
             <groupId>jakarta.servlet</groupId>
             <artifactId>jakarta.servlet-api</artifactId>
-            <version>4.0.2</version>
+            <version>4.0.4</version>
             <optional>true</optional>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.64</version>
+            <version>1.69</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.64</version>
+            <version>1.69</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.5.8</version>
+            <version>4.5.13</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -69,35 +69,35 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4.11</version>
+            <version>4.4.14</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
-            <version>1.7.26</version>
+            <version>1.7.32</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>1.7.26</version>
+            <version>1.7.32</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>1.7.26</version>
+            <version>1.7.32</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>no.digipost</groupId>
             <artifactId>digg</artifactId>
-            <version>0.19</version>
+            <version>0.30</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>27.1-jre</version>
+            <version>30.1.1-jre</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -119,7 +119,7 @@
         <dependency>
             <groupId>org.hamcrest</groupId>
             <artifactId>hamcrest</artifactId>
-            <version>2.1</version>
+            <version>2.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -131,13 +131,13 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>2.28.2</version>
+            <version>3.11.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>2.28.2</version>
+            <version>3.11.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -202,6 +202,7 @@
                                     <include>org.apache.commons:commons-lang3</include>
                                     <include>org.bouncycastle:bcprov-jdk15on</include>
                                     <include>org.bouncycastle:bcpkix-jdk15on</include>
+                                    <include>org.bouncycastle:bcutil-jdk15on</include>
                                     <include>commons-codec:commons-codec</include>
                                     <include>org.apache.httpcomponents:httpcore</include>
                                     <include>org.apache.httpcomponents:httpclient</include>

--- a/pom.xml
+++ b/pom.xml
@@ -153,7 +153,7 @@
                 <plugin>
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
-                    <version>3.0</version>
+                    <version>4.1</version>
                     <configuration>
                         <header>src/main/license-header.txt</header>
                         <strictCheck>true</strictCheck>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <project.previousVersion>set_with_-Dproject.previousVersion=X.Y</project.previousVersion>
     </properties>
 
     <dependencyManagement>
@@ -181,7 +182,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>3.0.0-M2</version>
+                    <version>3.0.0</version>
                     <configuration>
                         <rules>
                             <requireMavenVersion>
@@ -225,7 +226,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
-                    <version>3.0.0-M3</version>
+                    <version>3.0.0-M5</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-deploy-plugin</artifactId>
@@ -237,7 +238,7 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>3.1.1</version>
+                    <version>3.1.2</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-install-plugin</artifactId>
@@ -245,22 +246,29 @@
                 </plugin>
                 <plugin>
                     <artifactId>maven-resources-plugin</artifactId>
-                    <version>3.1.0</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>3.1.2</version>
+                    <version>3.2.0</version>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>2.8.1</version>
                 </plugin>
                 <plugin>
                     <groupId>com.github.siom79.japicmp</groupId>
                     <artifactId>japicmp-maven-plugin</artifactId>
-                    <version>0.14.1</version>
+                    <version>0.15.3</version>
                     <configuration>
+                        <oldVersion>
+                            <dependency>
+                                <groupId>${project.groupId}</groupId>
+                                <artifactId>${project.artifactId}</artifactId>
+                                <version>${project.previousVersion}</version>
+                            </dependency>
+                        </oldVersion>
                         <newVersion>
                             <file><path>${project.build.directory}/${project.build.finalName}.${project.packaging}</path></file>
                         </newVersion>

--- a/src/main/java/no/digipost/security/DigipostSecurity.java
+++ b/src/main/java/no/digipost/security/DigipostSecurity.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/DigipostSecurity.java
+++ b/src/main/java/no/digipost/security/DigipostSecurity.java
@@ -245,9 +245,10 @@ public final class DigipostSecurity {
         if (certificate instanceof X509Certificate) {
             X509Certificate x509 = (X509Certificate) certificate;
             String subjectDescription = x509.getSubjectX500Principal().getName();
+            String validityDescription = "valid from " + x509.getNotBefore().toInstant() + " to " + x509.getNotAfter().toInstant();
             String serialNumberDescription = "serial-number: " + x509.getSerialNumber().toString(16);
             String issuerDescription = x509.getSubjectX500Principal().equals(x509.getIssuerX500Principal()) ? "self-issued" : "issuer: " + x509.getIssuerX500Principal().getName();
-            return String.join(", ", subjectDescription, serialNumberDescription, issuerDescription);
+            return String.join(", ", subjectDescription, validityDescription, serialNumberDescription, issuerDescription);
         } else {
             return certificate.getType() + "-certificate";
         }

--- a/src/main/java/no/digipost/security/DigipostSecurityException.java
+++ b/src/main/java/no/digipost/security/DigipostSecurityException.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/Https.java
+++ b/src/main/java/no/digipost/security/Https.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/IllegalCertificateType.java
+++ b/src/main/java/no/digipost/security/IllegalCertificateType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/InvalidState.java
+++ b/src/main/java/no/digipost/security/InvalidState.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/NotSecure.java
+++ b/src/main/java/no/digipost/security/NotSecure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/X509.java
+++ b/src/main/java/no/digipost/security/X509.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/cert/CertHelper.java
+++ b/src/main/java/no/digipost/security/cert/CertHelper.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/cert/CertStatus.java
+++ b/src/main/java/no/digipost/security/cert/CertStatus.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/cert/CertificateNotFound.java
+++ b/src/main/java/no/digipost/security/cert/CertificateNotFound.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/cert/CertificateValidator.java
+++ b/src/main/java/no/digipost/security/cert/CertificateValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/cert/CertificateValidator.java
+++ b/src/main/java/no/digipost/security/cert/CertificateValidator.java
@@ -175,7 +175,7 @@ public class CertificateValidator {
                             ocspSignatureValidationCertificate = ocspSigningCertificate.get();
                             CertStatus certStatus = validateCert(ocspSignatureValidationCertificate, config.withOcspPolicy(NEVER_DO_OCSP_LOOKUP));
                             if (certStatus != OK) {
-                                LOG.warn("OCSP signing certificate {} is not OK: '{}'", describe(ocspSignatureValidationCertificate), certStatus);
+                                LOG.warn("OCSP signing certificate is '{}': {}", certStatus, describe(ocspSignatureValidationCertificate));
                                 return certStatus;
                             }
                         } else {

--- a/src/main/java/no/digipost/security/cert/CertificateValidatorConfig.java
+++ b/src/main/java/no/digipost/security/cert/CertificateValidatorConfig.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/cert/OcspDecision.java
+++ b/src/main/java/no/digipost/security/cert/OcspDecision.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/cert/OcspPolicy.java
+++ b/src/main/java/no/digipost/security/cert/OcspPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/cert/OcspSignatureValidator.java
+++ b/src/main/java/no/digipost/security/cert/OcspSignatureValidator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/cert/ReviewedCertPath.java
+++ b/src/main/java/no/digipost/security/cert/ReviewedCertPath.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/cert/RevocationReason.java
+++ b/src/main/java/no/digipost/security/cert/RevocationReason.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/cert/Trust.java
+++ b/src/main/java/no/digipost/security/cert/Trust.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/cert/Trust.java
+++ b/src/main/java/no/digipost/security/cert/Trust.java
@@ -37,6 +37,8 @@ import java.security.cert.PKIXParameters;
 import java.security.cert.TrustAnchor;
 import java.security.cert.X509CertSelector;
 import java.security.cert.X509Certificate;
+import java.time.Clock;
+import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -65,8 +67,14 @@ public class Trust {
 
     private final Set<X509Certificate> trustedCerts;
     private final Map<X500Principal, List<X509Certificate>> trustedIntermediateCerts;
+    private final Clock clock;
 
     public Trust(Stream<X509Certificate> rootCertificates, Stream<X509Certificate> intermediateCertificates) {
+        this(rootCertificates, intermediateCertificates, Clock.systemDefaultZone());
+    }
+
+    public Trust(Stream<X509Certificate> rootCertificates, Stream<X509Certificate> intermediateCertificates, Clock clock) {
+        this.clock = clock;
         this.trustedCerts = unmodifiableSet(rootCertificates.collect(toSet()));
         this.trustedIntermediateCerts = unmodifiableMap(intermediateCertificates.collect(groupingBy(X509Certificate::getSubjectX500Principal)));
     }
@@ -84,15 +92,18 @@ public class Trust {
         try {
             CollectionCertStoreParameters certStoreParams = new CollectionCertStoreParameters(
                     getTrustAnchorsAndAnyIntermediateCertificatesFor(certificate.getIssuerX500Principal()).collect(toSet()));
-            CertStore certStore = CertStore.getInstance("Collection", certStoreParams);
+
             X509CertSelector certSelector = new X509CertSelector();
             certSelector.setCertificate(certificate);
             certSelector.setSubject(certificate.getSubjectX500Principal());
+            certSelector.setCertificateValid(Date.from(clock.instant()));
 
+            CertStore certStore = CertStore.getInstance("Collection", certStoreParams);
             PKIXBuilderParameters params = new PKIXBuilderParameters(getTrustAnchors(), certSelector);
             params.addCertStore(certStore);
             params.setSigProvider(DigipostSecurity.PROVIDER_NAME);
             params.setRevocationEnabled(false);
+            params.setDate(Date.from(clock.instant()));
             CertPath certpath = CertPathBuilder.getInstance(PKIX).build(params).getCertPath();
             if (certpath.getCertificates().size() > 1) {
                 return new ReviewedCertPath(certpath, this::trusts);
@@ -105,7 +116,8 @@ public class Trust {
             }
 
         } catch (GeneralSecurityException e) {
-            LOG.warn("Error generating cert path. Certificate {} is not issued by trusted issuer. {}: {}", describe(certificate), e.getClass().getSimpleName(), e.getMessage());
+            LOG.warn("Error generating cert path for certificate, because the issuer is not trusted. {}: {}. certificate: {}",
+                    e.getClass().getSimpleName(), e.getMessage(), describe(certificate));
             if (LOG.isDebugEnabled()) {
                 LOG.debug(e.getClass().getSimpleName() + ": '" + e.getMessage() + "'", e);
             }
@@ -124,6 +136,7 @@ public class Trust {
             PKIXParameters params = new PKIXParameters(trustAnchors);
             params.setSigProvider(DigipostSecurity.PROVIDER_NAME);
             params.setRevocationEnabled(false);
+            params.setDate(Date.from(clock.instant()));
             CertPathValidator.getInstance(PKIX).validate(certPath, params);
             return true;
         } catch (CertPathValidatorException e) {

--- a/src/main/java/no/digipost/security/cert/TrustedCertificateAndIssuer.java
+++ b/src/main/java/no/digipost/security/cert/TrustedCertificateAndIssuer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/cert/Untrusted.java
+++ b/src/main/java/no/digipost/security/cert/Untrusted.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/crl/RevocationChecker.java
+++ b/src/main/java/no/digipost/security/crl/RevocationChecker.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/keystore/DuplicateAlias.java
+++ b/src/main/java/no/digipost/security/keystore/DuplicateAlias.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/keystore/KeyStoreBuilder.java
+++ b/src/main/java/no/digipost/security/keystore/KeyStoreBuilder.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/keystore/KeyStoreType.java
+++ b/src/main/java/no/digipost/security/keystore/KeyStoreType.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/ocsp/OcspLookup.java
+++ b/src/main/java/no/digipost/security/ocsp/OcspLookup.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/ocsp/OcspLookupRequest.java
+++ b/src/main/java/no/digipost/security/ocsp/OcspLookupRequest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/ocsp/OcspResult.java
+++ b/src/main/java/no/digipost/security/ocsp/OcspResult.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/ocsp/OcspUtils.java
+++ b/src/main/java/no/digipost/security/ocsp/OcspUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/main/java/no/digipost/security/ocsp/Sha1Calculator.java
+++ b/src/main/java/no/digipost/security/ocsp/Sha1Calculator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/security/DigipostSecurityTest.java
+++ b/src/test/java/no/digipost/security/DigipostSecurityTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/security/FilesAndDirs.java
+++ b/src/test/java/no/digipost/security/FilesAndDirs.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/security/HttpClient.java
+++ b/src/test/java/no/digipost/security/HttpClient.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/security/HttpsTest.java
+++ b/src/test/java/no/digipost/security/HttpsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/security/X509Test.java
+++ b/src/test/java/no/digipost/security/X509Test.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/security/cert/BuypassCommfidesCertificates.java
+++ b/src/test/java/no/digipost/security/cert/BuypassCommfidesCertificates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/security/cert/BuypassCommfidesCertificates.java
+++ b/src/test/java/no/digipost/security/cert/BuypassCommfidesCertificates.java
@@ -16,6 +16,7 @@
 package no.digipost.security.cert;
 
 import java.security.cert.X509Certificate;
+import java.time.Clock;
 import java.util.stream.Stream;
 
 import static java.util.stream.Stream.concat;
@@ -23,16 +24,16 @@ import static no.digipost.security.DigipostSecurity.readCertificate;
 
 public class BuypassCommfidesCertificates {
 
-    public static Trust createProdTrust() {
-        return new Trust(initTrustedCerts(false), initIntermediateTrust(false));
+    public static Trust createProdTrust(Clock clock) {
+        return new Trust(initTrustedCerts(false), initIntermediateTrust(false), clock);
     }
 
-    public static Trust createTestTrust() {
-        return new Trust(initTrustedCerts(true), initIntermediateTrust(true));
+    public static Trust createTestTrust(Clock clock) {
+        return new Trust(initTrustedCerts(true), initIntermediateTrust(true), clock);
     }
 
-    public static Trust createTestTrustIncluding(X509Certificate ... additionalTrustedCerts) {
-        return new Trust(concat(initTrustedCerts(true), Stream.of(additionalTrustedCerts)), initIntermediateTrust(true));
+    public static Trust createTestTrustWithAdditionalCerts(Clock clock, X509Certificate ... additionalTrustedCerts) {
+        return new Trust(concat(initTrustedCerts(true), Stream.of(additionalTrustedCerts)), initIntermediateTrust(true), clock);
     }
 
     private static Stream<X509Certificate> initTrustedCerts(boolean includeTestCerts) {

--- a/src/test/java/no/digipost/security/cert/CertificateValidatorTest.java
+++ b/src/test/java/no/digipost/security/cert/CertificateValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/security/cert/CertificateValidatorTest.java
+++ b/src/test/java/no/digipost/security/cert/CertificateValidatorTest.java
@@ -71,8 +71,8 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
-import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.quicktheories.QuickTheory.qt;
 import static org.quicktheories.generators.SourceDSL.integers;
 
@@ -311,7 +311,7 @@ public class CertificateValidatorTest {
         X509Certificate digipostCertWithoutOcspResponderUrl = digipostUtstedtTestsertifikat();
 
         assertThat(skipOcspForDigipostCert.validateCert(digipostCertWithoutOcspResponderUrl), is(OK));
-        verifyZeroInteractions(httpClient);
+        verifyNoInteractions(httpClient);
 
         CertificateValidator alwaysOcspValidator = new CertificateValidator(
                 MOST_STRICT.ignoreCustomSigningCertificatesInOcspResponses().validateOcspResponseSignatureUsing((ocspResponse, issuer) -> true),
@@ -322,8 +322,8 @@ public class CertificateValidatorTest {
 
         assertThat(alwaysOcspValidator.validateCert(digipostCertWithoutOcspResponderUrl), is(UNDECIDED));
 
-        verifyZeroInteractions(httpClient);
-        verifyZeroInteractions(ocspResponseEntity);
+        verifyNoInteractions(httpClient);
+        verifyNoInteractions(ocspResponseEntity);
 
         assertThat(alwaysOcspValidator.validateCert(digipostVirksomhetsTestsertifikat()), is(REVOKED));
 

--- a/src/test/java/no/digipost/security/cert/Certificates.java
+++ b/src/test/java/no/digipost/security/cert/Certificates.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/security/cert/RealOCSPCertificateValidatorTest.java
+++ b/src/test/java/no/digipost/security/cert/RealOCSPCertificateValidatorTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/security/cert/ReviewedCertPathTest.java
+++ b/src/test/java/no/digipost/security/cert/ReviewedCertPathTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/security/cert/RevocationReasonTest.java
+++ b/src/test/java/no/digipost/security/cert/RevocationReasonTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/security/cert/TrustTest.java
+++ b/src/test/java/no/digipost/security/cert/TrustTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/security/cert/TrustTest.java
+++ b/src/test/java/no/digipost/security/cert/TrustTest.java
@@ -24,6 +24,8 @@ import java.security.KeyStore;
 import java.security.KeyStoreException;
 import java.security.cert.CertPath;
 import java.security.cert.X509Certificate;
+import java.time.Clock;
+import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Set;
@@ -31,6 +33,7 @@ import java.util.stream.Stream;
 
 import static co.unruly.matchers.Java8Matchers.where;
 import static co.unruly.matchers.Java8Matchers.whereNot;
+import static java.time.ZoneOffset.UTC;
 import static java.util.stream.Collectors.toSet;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
@@ -47,7 +50,8 @@ public class TrustTest {
     private final X509Certificate commfidesRoot = DigipostSecurity.readCertificate("sertifikater/prod/commfides_root_ca.cer");
     private final X509Certificate commfidesIntermediate = DigipostSecurity.readCertificate("sertifikater/prod/commfides_ca.cer");
 
-    private final Trust trust = new Trust(Stream.of(buypassRoot, commfidesRoot), Stream.of(buypassIntermediate, commfidesIntermediate));
+    private final Trust trust = new Trust(Stream.of(buypassRoot, commfidesRoot), Stream.of(buypassIntermediate, commfidesIntermediate),
+            Clock.fixed(LocalDateTime.of(2020, 2, 10, 12, 0).toInstant(UTC), UTC));
 
     @Test
     public void returns_only_trust_anchors_when_no_intermediates_match_the_principal() {

--- a/src/test/java/no/digipost/security/ocsp/OcspLookupRequestTest.java
+++ b/src/test/java/no/digipost/security/ocsp/OcspLookupRequestTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/security/ocsp/OcspLookupTest.java
+++ b/src/test/java/no/digipost/security/ocsp/OcspLookupTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/security/ocsp/OcspResponses.java
+++ b/src/test/java/no/digipost/security/ocsp/OcspResponses.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/test/java/no/digipost/security/ocsp/OcspUtilsTest.java
+++ b/src/test/java/no/digipost/security/ocsp/OcspUtilsTest.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Copyright (C) Posten Norge AS
  *
  * Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
Instead of renewing the certificates used in tests yet another time because they expire from time to time, I decided to try and see if it was actually possible to parameterize which instant the JDK actually uses for validating, instead of implicitly reaching for the system clock. Turned out to [not being that complicated](https://github.com/digipost/certificate-validator/pull/21/files#diff-7978a09a7b2feabd45113d7f1de9fc4a390b93f29f3639eec873f26dbe58ee69) after all.

In addition:
- everything dependencies and plugins updated
- now [includes validity period](https://github.com/digipost/certificate-validator/pull/21/files#diff-d4e16365665ee9bb0c0cef5e2cc00b9970581fe8c194ef76f7af9ac8fced2a27) when describing certificates
- ignore the comment syntax change in every file, it's enforced from upgrading the license-maven-plugin
