### PR TITLE
Handle seid2 cert with orgnumber without recommended prefix

### DIFF
--- a/src/main/java/no/digipost/security/X509.java
+++ b/src/main/java/no/digipost/security/X509.java
@@ -44,7 +44,7 @@ public final class X509 {
     /**
      * SEID 2 way to embed Norwegian "organisasjonsnummer" in certificates.
      */
-    private static final Pattern SEID2_PATTERN = Pattern.compile("OID\\.2\\.5\\.4\\.97=NTRNO-([0-9]{9})", CASE_INSENSITIVE);
+    private static final Pattern SEID2_PATTERN = Pattern.compile("OID\\.2\\.5\\.4\\.97=(?:NTRNO-)?([0-9]{9})", CASE_INSENSITIVE);
 
 
     /**

--- a/src/test/java/no/digipost/security/X509Test.java
+++ b/src/test/java/no/digipost/security/X509Test.java
@@ -48,6 +48,12 @@ public class X509Test {
         assertThat(findOrganisasjonsnummer(cert).get(), is("123456789"));
     }
 
+    @Test
+    public void findOrganisasjonsnummerInSubjectWithoutPrefix() {
+        X509Certificate cert = mock(X509Certificate.class, RETURNS_DEEP_STUBS);
+        given(cert.getSubjectDN().getName()).willReturn("OID.2.5.4.97=123456789, CN=MyCorp Fullname, OU=MyCorp Department, O=MyCorp, C=NO");
+        assertThat(findOrganisasjonsnummer(cert).get(), is("123456789"));
+    }
 
     @Test
     public void doesNotFindOrganisasjonsnummer() {


### PR DESCRIPTION
Also accept SEID2 certificates with the subject format:
> SubjectDN: OID.2.5.4.97=123456789, CN=Common Name, ...etc