### PR TITLE
Upgrade to java-8-matchers 1.9

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,10 +124,16 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>co.unruly</groupId>
+            <groupId>uk.co.probablyfine</groupId>
             <artifactId>java-8-matchers</artifactId>
-            <version>1.6</version>
+            <version>1.9</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.hamcrest</groupId>
+                    <artifactId>hamcrest-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>

--- a/src/test/java/no/digipost/security/X509Test.java
+++ b/src/test/java/no/digipost/security/X509Test.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import java.security.cert.X509Certificate;
 import java.util.Optional;
 
-import static co.unruly.matchers.Java8Matchers.where;
+import static uk.co.probablyfine.matchers.Java8Matchers.where;
 import static no.digipost.security.X509.findOrganisasjonsnummer;
 import static no.digipost.security.cert.Certificates.BUYPASS_SEID_2_CERT;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/no/digipost/security/cert/ReviewedCertPathTest.java
+++ b/src/test/java/no/digipost/security/cert/ReviewedCertPathTest.java
@@ -26,8 +26,8 @@ import java.security.cert.CertificateParsingException;
 import java.util.Iterator;
 import java.util.stream.Stream;
 
-import static co.unruly.matchers.Java8Matchers.where;
-import static co.unruly.matchers.Java8Matchers.whereNot;
+import static uk.co.probablyfine.matchers.Java8Matchers.where;
+import static uk.co.probablyfine.matchers.Java8Matchers.whereNot;
 import static no.digipost.security.DigipostSecurity.asCertPath;
 import static no.digipost.security.DigipostSecurity.readCertificates;
 import static no.digipost.security.cert.Certificates.digipostVirksomhetssertifikat;

--- a/src/test/java/no/digipost/security/cert/TrustTest.java
+++ b/src/test/java/no/digipost/security/cert/TrustTest.java
@@ -31,8 +31,8 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.stream.Stream;
 
-import static co.unruly.matchers.Java8Matchers.where;
-import static co.unruly.matchers.Java8Matchers.whereNot;
+import static uk.co.probablyfine.matchers.Java8Matchers.where;
+import static uk.co.probablyfine.matchers.Java8Matchers.whereNot;
 import static java.time.ZoneOffset.UTC;
 import static java.util.stream.Collectors.toSet;
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/no/digipost/security/ocsp/OcspLookupRequestTest.java
+++ b/src/test/java/no/digipost/security/ocsp/OcspLookupRequestTest.java
@@ -22,7 +22,7 @@ import java.net.URI;
 import java.security.cert.X509Certificate;
 import java.util.List;
 
-import static co.unruly.matchers.Java8Matchers.where;
+import static uk.co.probablyfine.matchers.Java8Matchers.where;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;

--- a/src/test/java/no/digipost/security/ocsp/OcspLookupTest.java
+++ b/src/test/java/no/digipost/security/ocsp/OcspLookupTest.java
@@ -30,8 +30,8 @@ import java.net.SocketTimeoutException;
 import java.security.cert.X509Certificate;
 import java.util.List;
 
-import static co.unruly.matchers.Java8Matchers.where;
-import static co.unruly.matchers.Java8Matchers.whereNot;
+import static uk.co.probablyfine.matchers.Java8Matchers.where;
+import static uk.co.probablyfine.matchers.Java8Matchers.whereNot;
 import static java.util.stream.Collectors.toList;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;


### PR DESCRIPTION
Simple test-dependency update. Can be merged to `main` anytime.