### PR TITLE
Convert entire Trust to KeyStore

### DIFF
--- a/src/main/java/no/digipost/security/DigipostSecurity.java
+++ b/src/main/java/no/digipost/security/DigipostSecurity.java
@@ -43,6 +43,7 @@ import static java.util.Objects.requireNonNull;
 import static java.util.stream.Collectors.joining;
 import static java.util.stream.Collectors.toList;
 import static java.util.stream.StreamSupport.stream;
+import static javax.security.auth.x500.X500Principal.RFC1779;
 
 
 public final class DigipostSecurity {
@@ -244,10 +245,10 @@ public final class DigipostSecurity {
         }
         if (certificate instanceof X509Certificate) {
             X509Certificate x509 = (X509Certificate) certificate;
-            String subjectDescription = x509.getSubjectX500Principal().getName();
+            String subjectDescription = x509.getSubjectX500Principal().getName(RFC1779);
             String validityDescription = "valid from " + x509.getNotBefore().toInstant() + " to " + x509.getNotAfter().toInstant();
             String serialNumberDescription = "serial-number: " + x509.getSerialNumber().toString(16);
-            String issuerDescription = x509.getSubjectX500Principal().equals(x509.getIssuerX500Principal()) ? "self-issued" : "issuer: " + x509.getIssuerX500Principal().getName();
+            String issuerDescription = x509.getSubjectX500Principal().equals(x509.getIssuerX500Principal()) ? "self-issued" : "issuer: " + x509.getIssuerX500Principal().getName(RFC1779);
             return String.join(", ", subjectDescription, validityDescription, serialNumberDescription, issuerDescription);
         } else {
             return certificate.getType() + "-certificate";

--- a/src/main/java/no/digipost/security/X509.java
+++ b/src/main/java/no/digipost/security/X509.java
@@ -27,6 +27,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 import static java.util.regex.Pattern.CASE_INSENSITIVE;
+import static javax.security.auth.x500.X500Principal.RFC1779;
 
 public final class X509 {
 
@@ -39,11 +40,15 @@ public final class X509 {
 
     /**
      * Most common way to embed Norwegian "organisasjonsnummer" in certificates.
+     *
+     * @see <a href="http://www.oid-info.com/get/2.5.4.5">OID 2.5.4.5</a>
      */
-    private static final Pattern SERIALNUMBER_PATTERN = Pattern.compile("SERIALNUMBER=([0-9]{9})", CASE_INSENSITIVE);
+    private static final Pattern SERIALNUMBER_PATTERN = Pattern.compile("OID\\.2\\.5\\.4\\.5=([0-9]{9})", CASE_INSENSITIVE);
 
     /**
      * SEID 2 way to embed Norwegian "organisasjonsnummer" in certificates.
+     *
+     * @see <a href="http://www.oid-info.com/get/2.5.4.97">OID 2.5.4.97</a>
      */
     private static final Pattern SEID2_PATTERN = Pattern.compile("OID\\.2\\.5\\.4\\.97=(?:NTRNO-)?([0-9]{9})", CASE_INSENSITIVE);
 
@@ -52,7 +57,7 @@ public final class X509 {
      * Try to find Norwegian "organisasjonsnummer" in an {@link X509Certificate}.
      */
     public static final Optional<String> findOrganisasjonsnummer(X509Certificate certificate) {
-        String subjectDnName = certificate.getSubjectDN().getName();
+        String subjectDnName = certificate.getSubjectX500Principal().getName(RFC1779);
         return find(certificate,
                     cert -> tryFindOrgnr(subjectDnName, SEID2_PATTERN),
                     cert -> tryFindOrgnr(subjectDnName, SERIALNUMBER_PATTERN),

--- a/src/main/java/no/digipost/security/cert/Trust.java
+++ b/src/main/java/no/digipost/security/cert/Trust.java
@@ -275,12 +275,33 @@ public final class Trust {
 
 
     /**
-     * @return a {@link KeyStore} populated with the
+     * Get <em>only</em> the trust anchor certificates of this {@code Trust}
+     * as a {@link KeyStore}, a.k.a. a trust store. Consider using {@link #asKeyStore()}
+     * unless you have a very spesific need for only the trust anchors.
+     *
+     * @return a {@code KeyStore} populated with the
      *         {@link #getTrustAnchorCertificates() trust anchor certificates}
      *         of this {@code Trust}
+     *
+     * @see #asKeyStore()
      */
     public KeyStore getTrustAnchorsKeyStore() {
         return KeyStoreType.JCEKS.newKeyStore().containing(this.getTrustAnchorCertificates()).withNoPassword();
+    }
+
+
+    /**
+     * Get this {@code Trust} as a {@link KeyStore}, a.k.a. a trust store.
+     *
+     * @return a {@code KeyStore} populated with all the certificates
+     *         (both {@link #getTrustAnchorCertificates() trust anchors} and
+     *         {@link #getTrustedIntermediateCertificates() intermediate certificates})
+     *         of this {@code Trust}
+     */
+    public KeyStore asKeyStore() {
+        Stream<X509Certificate> trustAnchors = getTrustAnchorCertificates().stream();
+        Stream<X509Certificate> intermediateCerts = trustedIntermediateCerts.values().stream().flatMap(certs -> certs.stream());
+        return KeyStoreType.JCEKS.newKeyStore().containing(concat(trustAnchors, intermediateCerts)).withNoPassword();
     }
 
 

--- a/src/test/java/no/digipost/security/cert/TrustTest.java
+++ b/src/test/java/no/digipost/security/cert/TrustTest.java
@@ -38,7 +38,9 @@ import static no.digipost.security.cert.CertificatesForTesting.BUYPASS_SEID_2_CE
 import static no.digipost.security.cert.CertificatesForTesting.digipostVirksomhetsTestsertifikat;
 import static no.digipost.security.cert.CertificatesForTesting.digipostVirksomhetssertifikat;
 import static no.digipost.security.cert.ProdEnvCertificates.buypassClass3Ca3;
+import static no.digipost.security.cert.ProdEnvCertificates.buypassClass3CaG2HardToken;
 import static no.digipost.security.cert.ProdEnvCertificates.buypassClass3RootCa;
+import static no.digipost.security.cert.ProdEnvCertificates.buypassClass3RootCaG2HardToken;
 import static no.digipost.security.cert.ProdEnvCertificates.commfidesCa;
 import static no.digipost.security.cert.ProdEnvCertificates.commfidesRootCa;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -105,7 +107,7 @@ class TrustTest {
 
 
     @Test
-    void builds_keystore_with_certificates() throws KeyStoreException {
+    void builds_keystore_with_trust_anchor_certificates() throws KeyStoreException {
         Collection<X509Certificate> certificates = trust.getTrustAnchorCertificates();
         assertThat(certificates, hasSize(greaterThan(0)));
 
@@ -114,6 +116,18 @@ class TrustTest {
         assertThat(keystore.aliases(), where(Collections::list, hasSize(certificates.size())));
         for (String alias : Collections.list(keystore.aliases())) {
             assertTrue(keystore.isCertificateEntry(alias));
+        }
+    }
+
+    @Test
+    void convert_to_keystore() throws KeyStoreException {
+        Trust trust = Trust.in(clockSetWhenCertificatesAreValid, buypassClass3RootCaG2HardToken(), buypassClass3CaG2HardToken(), commfidesRootCa(), commfidesCa());
+        KeyStore keyStore = trust.asKeyStore();
+        assertThat(keyStore.aliases(), where(Collections::list, hasSize(4)));
+        assertThat(trust.getTrustAnchorsKeyStore().aliases(), where(Collections::list, hasSize(2)));
+
+        for (String alias : Collections.list(keyStore.aliases())) {
+            assertTrue(keyStore.isCertificateEntry(alias));
         }
     }
 


### PR DESCRIPTION
New method: `Trust.asKeyStore()`
This should probably replace most uses of the weirdly specific `Trust.getTrustAnchorsKeyStore()`.

In addition, minor change in how we resolve Norwegian organization numbers, by using `X500Principal` instead of the implementation specific `getSubjectDN()`, which is a so-called "denigraded" method.