### PR TITLE
Upgrade to BouncyCastle 1.70

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -159,10 +159,6 @@
         <pluginManagement>
             <plugins>
                 <plugin>
-                    <artifactId>maven-release-plugin</artifactId>
-                    <version>2.5.3</version>
-                </plugin>
-                <plugin>
                     <groupId>com.mycila</groupId>
                     <artifactId>license-maven-plugin</artifactId>
                     <version>4.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,12 +49,12 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
-            <version>1.69</version>
+            <version>1.70</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.69</version>
+            <version>1.70</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
             <dependency>
                 <groupId>org.junit</groupId>
                 <artifactId>junit-bom</artifactId>
-                <version>5.8.0-RC1</version>
+                <version>5.8.2</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -70,7 +70,7 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
-            <version>4.4.14</version>
+            <version>4.4.15</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
@@ -98,7 +98,7 @@
         <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <version>30.1.1-jre</version>
+            <version>31.0.1-jre</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -138,19 +138,19 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.12.1</version>
+            <version>4.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
-            <version>3.12.1</version>
+            <version>4.1.0</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>nl.jqno.equalsverifier</groupId>
             <artifactId>equalsverifier</artifactId>
-            <version>3.7.1</version>
+            <version>3.8.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/no/digipost/security/ocsp/OcspUtils.java
+++ b/src/main/java/no/digipost/security/ocsp/OcspUtils.java
@@ -72,7 +72,7 @@ public final class OcspUtils {
                     ASN1Encodable id = ((ASN1Sequence)elm).getObjectAt(0);
                     if (OCSPObjectIdentifiers.id_pkix_ocsp.equals(id)) {
                         ASN1TaggedObject dt = (ASN1TaggedObject)((DLSequence)elm).getObjectAt(1);
-                        ASN1OctetString dos =  (ASN1OctetString)dt.getObjectParser(dt.getTagNo(), true);
+                        ASN1OctetString dos =  ASN1OctetString.getInstance(dt, dt.isExplicit());
                         return Optional.of(URI.create(new String(dos.getOctets())));
                     }
                 }


### PR DESCRIPTION
Upgrading to BouncyCastle 1.70 broke the way we resolve the OCSP responder URL. This fixes it. Confirmed working with both the previous 1.69 version, and the current 1.70.