### PR TITLE
Log revoked as INFO instead of WARN

### DIFF
--- a/src/main/java/no/digipost/security/cert/CertificateValidator.java
+++ b/src/main/java/no/digipost/security/cert/CertificateValidator.java
@@ -188,10 +188,10 @@ public class CertificateValidator {
                                 if (cresp.getCertStatus() instanceof RevokedStatus) {
                                     RevokedStatus s = (RevokedStatus) cresp.getCertStatus();
                                     RevocationReason reason = Optional.of(s).filter(RevokedStatus::hasRevocationReason).map(r -> resolve(r.getRevocationReason())).orElse(unspecified);
-                                    LOG.warn("OCSP response for {} returned status revoked: {}, reason: '{}'", certificateAndIssuer, s.getRevocationTime(), reason);
+                                    LOG.info("OCSP response for {} returned status revoked: {}, reason: '{}'", certificateAndIssuer, s.getRevocationTime(), reason);
                                     return REVOKED;
                                 } else {
-                                    LOG.warn("OCSP response for {} returned status {}", certificateAndIssuer, cresp.getCertStatus().getClass().getSimpleName());
+                                    LOG.info("OCSP response for {} returned status {}", certificateAndIssuer, cresp.getCertStatus().getClass().getSimpleName());
                                     return UNDECIDED;
                                 }
                             }


### PR DESCRIPTION
Ikke noe å warn'e om, da OCSP-sjekken har utført den den skal; et revokert sertifikat har blitt identifisert. Samme for alle andre _non-good_ statuser, i praksis om et sertifikat er _ukjent_.

Målet er å få vekk sånne warns:
```
OCSP response for Trusted certificate: OID.2.5.4.5=974788985, CN=<Name>, O=<Name>, C=NO, valid from 2020-08-17T07:55:12Z to 2023-08-17T21:59:00Z, serial-number: 10fddef24badade992c015, issuer: CN=Buypass Class 3 CA 3, O=Buypass AS-983163327, C=NO, issued by CN=Buypass Class 3 CA 3, O=Buypass AS-983163327, C=NO, valid from 2012-09-25T08:05:19Z to 2032-09-25T08:05:19Z, serial-number: 1e, issuer: CN=Buypass Class 3 Root CA, O=Buypass AS-983163327, C=NO, OCSP-lookup may be done at http://ocsp.buypass.no/ocsp/BPClass3CA3 returned status revoked: Fri Jul 30 14:31:49 CEST 2021, reason: 'unspecified (0)'
```